### PR TITLE
Added  "npm install" before 'npm run dev'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 First, run the development server:
 
 ```bash
+npm install
 npm run dev
 # or
 yarn dev

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ First, run the development server:
 
 ```bash
 npm install
+# or
+yarn install
+
 npm run dev
 # or
 yarn dev


### PR DESCRIPTION
Required package installation is necessary whenever a project is run in a new server.
So `npm install`  is being added before `npm run` in every react based project, so that the all the required packages will be installed to run the project.
This helps the folks who tries to **contribute** to your project.